### PR TITLE
Added a new 'setup.sh' script

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,29 @@
 
 I recommend cloning this repository inside an existing directory that's just
 for this project.  The sqlite database will be created one directory up from
-the repo, and that's also where I recommend you put your virtualenv.
+the repo, and that's also where I recommend you put your virtualenv and the
+setup script below will do the that.
 
-So, create a virtualenv outside the repo, install packages from
-`requirements.txt` for Python 2, or `p3req.txt` for Python 3, into it.  I
-haven't picked a Python version (yet); if I haven't messed up, 2.7 and 3.4
-should both work.  Trying to stay compatible with both.  See 'compatibility'
-section below.
+## setup script
+
+Run the setup script, give the python version you wish to use as the only
+argument.
+
+    source setup.sh 3.4
+
+This will create a virtual environment, activate it, and install all of the
+dependencies.
+
+## Test Python Versions
+
+The `test_python_versions` script will test different versions of python. It
+will call the setup script with different arguments, currently just the 2.7 and
+3.4 versions are called but more can easily be added. Worth looking in the
+script to see the arguments, but none will cause it to call the entire test
+suite, `quick` will just run a single test module and `coverage` will run the
+coverage analysis in both versions.
+
+## Database
 
 Run `db_remake.py` to create the database (by default it will appear one
 directory level higher than your repository root).

--- a/manage.py
+++ b/manage.py
@@ -77,6 +77,8 @@ def create_login_session_internal(email):
 
 @manager.command
 def test_module(module):
+    """ For example you might do `python manage.py test_module app.tests.test'
+    """
     os.system("python -m unittest " + module)
 
 @manager.command

--- a/p3req.txt
+++ b/p3req.txt
@@ -10,6 +10,7 @@ Tempita==0.5.2
 WTForms==2.0.1
 Werkzeug==0.9.6
 argparse==1.2.1
+coverage==3.7.1
 decorator==3.4.0
 enum34==1.0.4
 future==0.14.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,5 @@ selenium==2.44.0
 six==1.8.0
 sqlparse==0.1.14
 wsgiref==0.1.2
+coverage==3.7.1
+

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,43 @@
+#! /bin/sh
+
+# If the first argument is there it will be the python version
+if [ $# -gt 0 ]
+then
+PYTHONVERSION=$1
+else
+PYTHONVERSION=3.4
+fi
+
+# If there is a second argument it is the directory to create the
+# virtual environment in.
+if [ $# -gt 1 ]
+then
+    VENV=$2
+else
+    VENV="tmpvenv"
+fi
+
+# Creating a virtual environment and which requirements file to use depends
+# upon which version of python we are using.
+if [ $(echo "$PYTHONVERSION < 3.0" | bc) -ne 0 ] 
+then
+    PYVENV=virtualenv
+    REQUIREMENTS=requirements.txt
+else
+    PYVENV=pyvenv
+    REQUIREMENTS=p3req.txt
+fi
+
+# Finally we can go about creating the virtual environment and installing
+# all of the dependencies.
+cd ../
+${PYVENV} ${VENV}
+source ${VENV}/bin/activate
+
+# This essentially writes a small sitecustomize.py file into the virtual
+# environment, this is required for coverage to work with subprocesses.
+SITECUSTOMIZE="${VENV}/lib/python${PYTHONVERSION}/site-packages/sitecustomize.py"
+echo import coverage >> ${SITECUSTOMIZE}
+echo "coverage.process_startup()" >> ${SITECUSTOMIZE}
+cd drunken-octo-avenger
+pip install -r ${REQUIREMENTS}

--- a/test_python_versions.sh
+++ b/test_python_versions.sh
@@ -1,0 +1,25 @@
+#! /bin/sh
+
+TEST_COMMAND="python manage.py test_all"
+
+if [ "$1" == "coverage" ]
+then
+TEST_COMMAND="python manage.py coverage"
+fi
+
+if [ "$1" == "quick" ]
+then
+TEST_COMMAND="python manage.py test_module app.tests.test"
+fi
+
+echo $TEST_COMMAND
+
+test_python(){
+    rm -fr ../testvenv$1
+    source setup.sh $1 testvenv$1
+    $TEST_COMMAND
+    deactivate
+}
+
+test_python 3.4
+test_python 2.7


### PR DESCRIPTION
The new 'setup.sh' script will set up the development environment for the given python version. I have then also added a second script 'test_python_versions.sh' which will use the first script to test separate versions of python. I've updated the README to reflect this and I've also updated both requirements files to include 'coverage'.

Note that the 'setup.sh' script also accepts the virtual environment directory to use, so for 'test_python_versions.sh' it uses separate ones which it knows it can remove before re-trying if they are there. This is not exactly testing all python versions, and it currently has no way of knowing whether the tests actually succeed (you have to look at those yourself) but at least it is a start.