### PR TITLE
Persona login with bonus logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ In the repository root directory, run
 Access the local server at `http://localhost:5000` by default (other domains
 will need to be set in `config.py` to avoid confusing the login system).
 
+Note: When you run the server it may tell you that it is:
+
+    Running on http://127.0.0.1:5000/
+
+If you actually go there though you will not be able to login via persona
+because there will be an audience and domain mismatch. So make sure you visit
+`http://localhost:5000` instead.
+
 ## testing
 
 ### Python code

--- a/app/main.py
+++ b/app/main.py
@@ -6,6 +6,7 @@ from builtins import (ascii, bytes, chr, dict, filter, hex, input,  # noqa
 
 from collections import namedtuple
 from enum import IntEnum
+import logging
 
 from flask import (
         Flask, abort, flash, redirect, render_template, request, session,
@@ -29,6 +30,8 @@ IMG_PATH_WHITE = '/static/images/goban/w.gif'
 app = Flask(__name__)
 app.config.from_object('config')
 app.jinja_env.undefined = jinja2.StrictUndefined
+if app.debug:
+    logging.basicConfig(level=logging.DEBUG)
 db = SQLAlchemy(app)
 
 
@@ -153,6 +156,7 @@ def process_persona_response(response):
     Pure function.
     """
     if not response.ok:
+        logging.debug("Response not 'ok' for persona login attempt")
         return _SessionUpdate(do=False, email='')
     verification_data = response.json()
     if (
@@ -160,6 +164,8 @@ def process_persona_response(response):
             verification_data['status'] != 'okay' or
             'email' not in verification_data
     ):
+        logging.debug("Persona login has a problem with the verification data")
+        logging.debug(str(verification_data))
         return _SessionUpdate(do=False, email='')
     return _SessionUpdate(do=True, email=verification_data['email'])
 

--- a/config.py
+++ b/config.py
@@ -9,6 +9,8 @@ basedir = os.path.abspath(os.path.dirname(__file__))
 
 DOMAIN = 'localhost'
 
+DEBUG = True
+
 SQLALCHEMY_DATABASE_URI = 'sqlite:///' + os.path.join(basedir, '../db.sqlite')
 
 SECRET_KEY = ':\x8dkR\xf9\x05\xc2\xd2,\xd4t\x0f\x0bvB\xbb\x1a.\xce\xbd\x0b\x17\xdc\xb7'  # noqa


### PR DESCRIPTION
Updated the readme to detail the problem when locally running the server when you visit 127.0.0.1 rather than localhost. I've also added in a log statement when the persona login fails for this reason. This has meant introducing the standard logging framework which we should probably use a bit more often. Finally this has meant adding 'DEBUG = True' to the development configuration which is what I think we want anyway.

Note, when you use print statements for debugging, you're better off using logging.debug, because at least then if you accidentally leave one live it won't be executed on production.