### PR TITLE
Minor style

### DIFF
--- a/app/go_rules.py
+++ b/app/go_rules.py
@@ -17,6 +17,9 @@ class Board(object):
                         for r in range(size)
                         for c in range(size)}
 
+    def __getitem__(self, coords):
+        return self._points[coords]
+
     def get_point(self, r, c):
         return self._points[(r, c)]
 

--- a/app/main.py
+++ b/app/main.py
@@ -338,13 +338,9 @@ def get_rules_board_from_db_objects(moves, setup_stones):
     """
 
     def rules_color(db_color):
-        if db_color == Move.Color.black:
-            color = go_rules.Color.black
-        elif db_color == Move.Color.white:
-            color = go_rules.Color.white
-        else:
-            color = go_rules.Color.empty
-        return color
+        mapping = {Move.Color.black: go_rules.Color.black,
+                   Move.Color.white: go_rules.Color.white}
+        return mapping.get(db_color, go_rules.Color.empty)
 
     def place_stones_for_move(n):
         for stone in filter(lambda s: s.before_move == n, setup_stones):
@@ -404,10 +400,7 @@ def get_status_lists(player_email):
     """
     all_games = Game.query.all()
     current_player_games = get_player_games(player_email, all_games)
-    games_to_moves = [
-            (game, game.moves,)
-            for game in current_player_games
-    ]
+    games_to_moves = [(game, game.moves,) for game in current_player_games]
     your_turn_games, not_your_turn_games = partition_by_turn(
             player_email, games_to_moves)
     return (your_turn_games, not_your_turn_games,)

--- a/app/main.py
+++ b/app/main.py
@@ -376,21 +376,23 @@ def get_goban_data_from_rules_board(rules_board):
     black = go_rules.Color.black
     white = go_rules.Color.white
     empty = go_rules.Color.empty
-    goban = [[dict(
-        img=IMG_PATH_EMPTY,
-        classes='gopoint row-{row} col-{col}'.format(row=str(j), col=str(i))
-    )
+
+    color_images = {black: IMG_PATH_BLACK,
+                    white: IMG_PATH_WHITE,
+                    empty: IMG_PATH_EMPTY}
+    color_classes = {black: 'blackstone', 
+                     white: 'whitestone',
+                     empty: 'nostone'}
+
+    def create_goban_point(row, column, color):
+        classes_template = 'gopoint row-{row} col-{col} {color_class}'
+        classes = classes_template.format(row=str(row),
+                                          col=str(column),
+                                          color_class=color_classes[color])
+        return dict(img=color_images[color], classes=classes)
+    goban = [[create_goban_point(j, i, rules_board[j,i])
              for i in range(19)]
              for j in range(19)]
-    for (r, c), color in rules_board.items():
-        if color == black:
-            goban[r][c]['img'] = IMG_PATH_BLACK
-            goban[r][c]['classes'] += ' blackstone'
-        elif color == white:
-            goban[r][c]['img'] = IMG_PATH_WHITE
-            goban[r][c]['classes'] += ' whitestone'
-        elif color == empty:
-            goban[r][c]['classes'] += ' nostone'
     return goban
 
 def get_status_lists(player_email):


### PR DESCRIPTION
Minor refactors for style. I've added a '__getitem__' method to `go_rules.Board` this means you can get the color of a point with `board[row,col]`, we could also get rid of `Board.get_point`. We could also implement `__setitem__` and then we can get rid of `set_point`, then we can set places on the board with simply `board[row,col] = color`. Note, that it is recommended not to implement `__setitem__` if extra keys cannot be defined. For us, extra keys *can* be defined, but it is questionable whether we would want to. In any case I still think that is worth it, even if `__setitem__` checks the range of the subscription and throws an error in the case that is invalid. Which arguably `set_point` should do so anyway. 