### PR TITLE
Completed the move from go_rules.Board.get_point and set_point to using ...

### DIFF
--- a/app/go_rules.py
+++ b/app/go_rules.py
@@ -18,13 +18,12 @@ class Board(object):
                         for c in range(size)}
 
     def __getitem__(self, coords):
+        """ Coords should be a pair consisting of row and column numbers """
         return self._points[coords]
 
-    def get_point(self, r, c):
-        return self._points[(r, c)]
-
-    def set_point(self, r, c, color):
-        self._points[(r, c)] = color
+    def __setitem__(self, coords, color):
+        """ As above, coords should be a pair consisting of row and column """
+        self._points[coords] = color
 
     def items(self):
         return self._points.items()

--- a/app/main.py
+++ b/app/main.py
@@ -344,8 +344,7 @@ def get_rules_board_from_db_objects(moves, setup_stones):
 
     def place_stones_for_move(n):
         for stone in filter(lambda s: s.before_move == n, setup_stones):
-            board.set_point(stone.row, stone.column,
-                            rules_color(stone.color))
+            board[stone.row, stone.column] = rules_color(stone.color)
 
     board = go_rules.Board()
     for move in sorted(moves, key=lambda m: m.move_no):

--- a/app/tests/test.py
+++ b/app/tests/test.py
@@ -424,10 +424,10 @@ class TestGetRulesBoardFromDbObjects(unittest.TestCase):
         moves = [Move(game.id, 0, 2, 3, Move.Color.black)]
         setup_stones = main.get_stones_from_text_map(['.bw'], game)
         board = main.get_rules_board_from_db_objects(moves, setup_stones)
-        self.assertEqual(board.get_point(0, 0), go_rules.Color.empty)
-        self.assertEqual(board.get_point(0, 1), go_rules.Color.black)
-        self.assertEqual(board.get_point(0, 2), go_rules.Color.white)
-        self.assertEqual(board.get_point(2, 3), go_rules.Color.black)
+        self.assertEqual(board[0, 0], go_rules.Color.empty)
+        self.assertEqual(board[0, 1], go_rules.Color.black)
+        self.assertEqual(board[0, 2], go_rules.Color.white)
+        self.assertEqual(board[2, 3], go_rules.Color.black)
 
     def test_setup_stones(self):
         """Regression test: need to process setup stones after last move.
@@ -438,14 +438,14 @@ class TestGetRulesBoardFromDbObjects(unittest.TestCase):
         moves = []
         setup_stones = main.get_stones_from_text_map(['.bw'], game)
         board = main.get_rules_board_from_db_objects(moves, setup_stones)
-        self.assertEqual(board.get_point(0, 1), go_rules.Color.black)
+        self.assertEqual(board[0, 1], go_rules.Color.black)
 
 class TestGetGobanDataFromRulesBoard(unittest.TestCase):
 
     def test_simple(self):
         board = go_rules.Board()
-        board.set_point(0, 1, go_rules.Color.black)
-        board.set_point(1, 2, go_rules.Color.white)
+        board[0, 1] = go_rules.Color.black
+        board[1, 2] = go_rules.Color.white
         goban = main.get_goban_data_from_rules_board(board)
         assert 'b.gif' in goban[0][1]['img']
         assert 'blackstone' in goban[0][1]['classes']

--- a/app/tests/test_go_rules.py
+++ b/app/tests/test_go_rules.py
@@ -22,9 +22,9 @@ def board_from_strings(rows):
     for r, row in enumerate(rows):
         for c, char in enumerate(row):
             if char == 'b':
-                board.set_point(r, c, black)
+                board[r, c] = black
             elif char == 'w':
-                board.set_point(r, c, white)
+                board[r, c] = white
     return board
 
 class TestUpdateBoardWithMove(unittest.TestCase):


### PR DESCRIPTION
...'__getitem__' and '__setitem__' such that we can just use subscription syntax, which I think makes most uses easier to read. I think the subscription of a go board is pretty intuitive.