### PR TITLE
Make the pytest browser tests work again.

### DIFF
--- a/app/tests/browser_tests.py
+++ b/app/tests/browser_tests.py
@@ -33,7 +33,7 @@ def get_url(local_url='/'):
     # Obviously this is not the same application instance as the running
     # server and hence the LIVESERVER_PORT could in theory be different,
     # but for testing purposes we just make sure it this is correct.
-    port = app.config['LIVESERVER_PORT']
+    port = app.config['TESTSERVER_PORT']
     return 'http://localhost:{}/{}'.format(port, local_url)
 
 # Note, we could write these additional assert methods in a class which

--- a/manage.py
+++ b/manage.py
@@ -158,7 +158,8 @@ def run_with_test_server(test_command, coverage, accumulate):
     # we have to make a request so that the server process can shut down
     # cleanly, and in particular finalise coverage analysis.
     # We could check the return from this is success.
-    requests.post('http://localhost:5000/shutdown')
+    port = app.config['TESTSERVER_PORT']
+    requests.post('http://localhost:{}/shutdown'.format(port))
     server_return_code = server.wait(timeout=90)
     if coverage:
         os.system("coverage report -m")

--- a/manage.py
+++ b/manage.py
@@ -1,5 +1,6 @@
 import os
 import subprocess
+import errno
 
 import flask
 from flask.ext.migrate import Migrate, MigrateCommand
@@ -160,7 +161,11 @@ def run_with_test_server(test_command, coverage, accumulate):
     # We could check the return from this is success.
     port = app.config['TESTSERVER_PORT']
     requests.post('http://localhost:{}/shutdown'.format(port))
-    server_return_code = server.wait(timeout=90)
+    try:
+        server_return_code = server.wait(timeout=90)
+    except subprocess.TimeoutExpired:
+        server.kill()
+        server_return_code = errno.ETIME
     if coverage:
         os.system("coverage report -m")
         os.system("coverage html")


### PR DESCRIPTION
Do this by referring to TESTSERVER_PORT rather than LIVESERVER_PORT.
I've also updated `run_test_with_server` so that it posts to the correct url in order to shutdown the server. This was why the casperJS tests were reported as failing when they were passing.
